### PR TITLE
Add dark theme support using media queries api

### DIFF
--- a/src/Styles/WeatherCard.css
+++ b/src/Styles/WeatherCard.css
@@ -28,3 +28,16 @@ p {
   margin-bottom: 0;
   color: #444;
 }
+@media (prefers-color-scheme: dark) {
+  .weather-card {
+    background-color: black;
+    color: white;
+    border: 1px solid #8840e8;
+    border-radius: 0.4rem;
+  }
+
+  h1,
+  h2 {
+    color: white;
+  }
+}

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -37,7 +37,8 @@ const { href, title, icon, body } = Astro.props;
     border-radius: 0.5rem;
     background-position: 100%;
     transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    box-shadow:
+      0 4px 6px -1px rgba(0, 0, 0, 0.1),
       0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
 
@@ -66,5 +67,16 @@ const { href, title, icon, body } = Astro.props;
   }
   .link-card:is(:hover, :focus-within) h2 {
     color: rgb(var(--accent));
+  }
+  @media (prefers-color-scheme: dark) {
+    .link-card > a {
+      background-color: black;
+    }
+    h2 {
+      color: white;
+    }
+    p {
+      color: grey;
+    }
   }
 </style>

--- a/src/components/CardNoBody.astro
+++ b/src/components/CardNoBody.astro
@@ -26,7 +26,8 @@ const { href, title } = Astro.props;
     border-radius: 0.5rem;
     background-position: 100%;
     transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    box-shadow:
+      0 4px 6px -1px rgba(0, 0, 0, 0.1),
       0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
 
@@ -55,5 +56,16 @@ const { href, title } = Astro.props;
   }
   .link-card:is(:hover, :focus-within) h2 {
     color: rgb(var(--accent));
+  }
+  @media (prefers-color-scheme: dark) {
+    .link-card > a {
+      background-color: black;
+    }
+    h2 {
+      color: white;
+    }
+    p {
+      color: grey;
+    }
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ export interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -33,8 +33,30 @@ const { title } = Astro.props;
     font-family: system-ui, sans-serif;
     background-color: #f6f6f6;
   }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --accent: 124, 58, 237;
+      --accent-gradient: linear-gradient(
+        45deg,
+        rgb(var(--accent)),
+        #da62c4 30%,
+        grey 60%
+      );
+    }
+    html {
+      background-color: black;
+      color: white;
+    }
+  }
   code {
-    font-family: Menlo, Monaco, Lucida Console, Liberation Mono,
-      DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
+    font-family:
+      Menlo,
+      Monaco,
+      Lucida Console,
+      Liberation Mono,
+      DejaVu Sans Mono,
+      Bitstream Vera Sans Mono,
+      Courier New,
+      monospace;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -98,4 +98,15 @@ import WeatherCard from "../components/WeatherCard.jsx";
     gap: 1rem;
     padding: 0;
   }
+
+  @media (prefers-color-scheme: dark) {
+    .description {
+      background-color: black;
+      color: white;
+      border: 1px solid #8840e8;
+    }
+    h1 {
+      color: white;
+    }
+  }
 </style>


### PR DESCRIPTION
This PR adds dark theme to the page using media query, selecting the preferred color scheme set by os, browser settings or user-agent preferences.